### PR TITLE
feat: lru-cache support for manager added

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
   },
   "homepage": "https://github.com/bracketedrebels/sentites#readme",
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash": "4.17.4",
+    "lru-cache": "4.0.2"
   },
   "devDependencies": {
     "@types/jasmine": "*",
     "@types/lodash": "4.14.61",
     "@types/node": "7.0.5",
+    "@types/lru-cache": "4.0.0",
     "husky": "^0.13.2",
     "jasmine": "^2.5.2",
     "lint-staged": "^3.3.1",

--- a/src/manager.class.spec.ts
+++ b/src/manager.class.spec.ts
@@ -2,20 +2,45 @@ import 'jasmine';
 
 import { Entity } from './entity.class';
 import { Manager } from './manager.class';
+import { Tag } from './tag.decorator';
 import { ALL } from './query.helpers';
+
+@Tag() class TAG {}
 
 describe(`Manager`, () => {
     const manager = new Manager();
+    const managerWithCache = new Manager(1);
 
     it(`should create an instance`, () => {
         expect(manager).toBeTruthy();
+        expect(managerWithCache).toBeTruthy();
     });
     it(`should correctly create entities`, () => {
         expect(manager.create() instanceof Entity).toBeTruthy();
+        expect(managerWithCache.create() instanceof Entity).toBeTruthy();
     });
     it(`should correctly accumulate created entities`, () => {
         let entities = manager.query(ALL);
         entities.push(manager.create());
         expect(manager.query(ALL).sort()).toEqual(entities.sort());
+        entities = managerWithCache.query(ALL);
+        entities.push(managerWithCache.create());
+        expect(managerWithCache.query(ALL).sort()).toEqual(entities.sort());
+    });
+    it(`should correctly cache queries`, () => {
+        for (let i = 0; i < 100000; i++) {
+            managerWithCache.create()
+        }
+        for (let j = 0; j < 10; j++) {
+            managerWithCache.create();
+            let start = Date.now();
+            managerWithCache.query(TAG);
+            let nonCachedQueryExecutionDuration = Date.now() - start;
+            start = Date.now();
+            managerWithCache.query(TAG);
+            let cachedQueryExecutionDuration = Date.now() - start;
+
+            expect(nonCachedQueryExecutionDuration).toBeGreaterThan(cachedQueryExecutionDuration);
+        }
     });
 });


### PR DESCRIPTION
now you are able to pass number as an argument while creating a Manager instance in order to specifiy lru-cache size. If no or zero value specified, cache will be disabled.